### PR TITLE
pint values for unit conversion

### DIFF
--- a/obdpi/obd_manager.py
+++ b/obdpi/obd_manager.py
@@ -3,8 +3,6 @@ import obd
 
 class ObdManager:
 
-    KPA_TO_PSI_CONVERSION_FACTOR = 0.145038
-
     def __init__(self):
         self.obd_connection = ""
 
@@ -26,17 +24,17 @@ class ObdManager:
         if self.has_obd_connection():
             if command == "RPM":
                 obd_command = obd.commands.RPM
-                obd_unit = str(obd.Unit.RPM)
+                obd_unit = "RPM"
             elif command == "BOOST":
                 obd_command = obd.commands.INTAKE_PRESSURE
-                obd_unit = str(obd.Unit.PSI)
+                obd_unit = "PSI"
             else:
                 return "'" + command + "' is unrecognized OBD command"
                 
             obd_response = self.obd_connection.query(obd_command)
             
             if not obd_response.is_null():
-                converted_obd_response = round(obd_response.value * self.KPA_TO_PSI_CONVERSION_FACTOR, 3)
+                converted_obd_response = round(obd_response.value.to("psi").magnitude, 3)
                 return str(converted_obd_response) + " " + obd_unit
             else:
                 return "No OBD response"


### PR DESCRIPTION
I felt bad for releasing breaking changes... So here's a PR for the latest python-OBD (0.6.0) that has the unit-aware facilities you requested.

One item of note. You'll notice I hard-coded those unit strings. I originally tried to use Pint's unit names, but these particular ones returned ugly sentence-like names:

``` python
>>> str(obd.Unit.psi)
'pound_force_per_square_inch'
```

Those are built into Pint, but if I come up with a way to get cleaner names, I'll let you know.
